### PR TITLE
디테일 페이지 데이터 연동

### DIFF
--- a/DOTORI/Controller/MyPageViewController.swift
+++ b/DOTORI/Controller/MyPageViewController.swift
@@ -11,7 +11,7 @@ import WebKit
 class MyPageViewController: UIViewController, WKNavigationDelegate {
     
     var myPostings: [PostingInfo] = []
-
+    var selectedUserName : String? //디테일페이지에서 클릭한 프로필의 유저 이름
     @IBOutlet weak var mainTitle: UILabel!
     @IBOutlet weak var mySetting: UIButton!
     @IBOutlet weak var profileImage: UIImageView!
@@ -52,6 +52,10 @@ class MyPageViewController: UIViewController, WKNavigationDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        if let text = selectedUserName
+        {
+            name.text = text
+        }
         
         
         /*

--- a/DOTORI/Controller/ViewController.swift
+++ b/DOTORI/Controller/ViewController.swift
@@ -15,26 +15,36 @@ class ViewController: UIViewController {
         //더미데이터들
 
     }
-
+    var selectedIndex : Int?
 }
 extension ViewController : UITableViewDelegate, UITableViewDataSource {
+ 
     func tableView(_ tableView : UITableView, numberOfRowsInSection section : Int) -> Int {
         return data.count
     }
-    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "CustomTableViewCell", for: indexPath)
                 as? CustomTableViewCell else { return UITableViewCell() }
         cell.posting_content.text = data[indexPath.row].content
         cell.posting_contentimage.image = data[indexPath.row].contentImage
-        cell.posting_time.text = data[indexPath.row].createTime.GetCurrentTime()
+        cell.posting_time.text = data[indexPath.row].createTime.GetCurrentTime(format: "yyyy-MM-dd")
         cell.profile_image.image = data[indexPath.row].user.profileImage
         cell.profile_nickname.text = data[indexPath.row].user.nickname
         return cell
     }
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         //셀 선택시 함수
+        selectedIndex = indexPath.row
         performSegue(withIdentifier: "HomeToDetail", sender: self)
+    }
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+     
+        if segue.identifier == "HomeToDetail" {
+            if let destinationVC = segue.destination as? DetailViewController {
+                destinationVC.selectedIndex = selectedIndex!
+
+            }
+        }
     }
 }
 

--- a/DOTORI/Dummy/Dummy.swift
+++ b/DOTORI/Dummy/Dummy.swift
@@ -6,19 +6,27 @@
 //
 
 import Foundation
+import UIKit
 
-var user1 = UserInfo(name: "김서온", nickname: "김서오니", githubUrl: "", blogUrl: "", userIntro: "")
-var user2 = UserInfo(name: "이찬호", nickname: "lcho3878", githubUrl: "", blogUrl: "", userIntro: "")
-var user3 = UserInfo(name: "이대현", nickname: "hidaehyun", githubUrl: "", blogUrl: "", userIntro: "")
-var user4 = UserInfo(name: "박유경", nickname: "hiyukyung", githubUrl: "", blogUrl: "", userIntro: "")
-var user5 = UserInfo(name: "박지근", nickname: "지끈지끈", githubUrl: "", blogUrl: "", userIntro: "")
+var user1 = UserInfo(profileImage :UIImage(named: "defaultProfileImage"), name: "김서온", nickname: "김서오니", githubUrl: "", blogUrl: "", userIntro: "")
+var user2 = UserInfo(profileImage :UIImage(systemName: "lasso"),name: "이찬호", nickname: "lcho3878", githubUrl: "", blogUrl: "", userIntro: "")
+var user3 = UserInfo(profileImage :UIImage(systemName: "bookmark"),name: "이대현", nickname: "hidaehyun", githubUrl: "", blogUrl: "", userIntro: "")
+var user4 = UserInfo(profileImage :UIImage(systemName: "bookmark.fill"),name: "박유경", nickname: "hiyukyung", githubUrl: "", blogUrl: "", userIntro: "")
+var user5 = UserInfo(profileImage :UIImage(named: "image1"),name: "박지근", nickname: "지끈지끈", githubUrl: "", blogUrl: "", userIntro: "")
 
-var posting1 = PostingInfo(user: user1, category: "잡담", content: "아니에요", createTime: Date(), updateTime: Date(), bookmark: false, bookmarkCount: 0, reply: [reply1], tilUrl: "")
-var posting2 = PostingInfo(user: user2, category: "잡담", content: "타닥타닥", createTime: Date(), updateTime: Date(), bookmark: false, bookmarkCount: 0, reply: [], tilUrl: "")
-var posting3 = PostingInfo(user: user3, category: "질문", content: "저녁 뭐먹을까요?", createTime: Date(), updateTime: Date(), bookmark: false, bookmarkCount: 0, reply: [], tilUrl: "")
-var posting4 = PostingInfo(user: user4, category: "고양이방", content: "야옹", createTime: Date(), updateTime: Date(), bookmark: false, bookmarkCount: 0, reply: [], tilUrl: "")
-var posting5 = PostingInfo(user: user5, category: "TIL", content: "UserDefault", createTime: Date(), updateTime: Date(), bookmark: true, bookmarkCount: 0, reply: [], tilUrl: "")
+var posting1 = PostingInfo(user: user1, category: "잡담", content: "아니에요", createTime: Date(), updateTime: Date(),contentImage: UIImage(named: "defaultProfileImage"),bookmark: false, bookmarkCount: 0, reply: [reply1,reply2,reply3], tilUrl: "")
+var posting2 = PostingInfo(user: user2, category: "잡담", content: "타닥타닥", createTime: Date(), updateTime: Date(), contentImage: UIImage(systemName: "bookmark"),bookmark: false, bookmarkCount: 0, reply: [reply1,reply4,reply2,reply3], tilUrl: "")
+var posting3 = PostingInfo(user: user3, category: "질문", content: "저녁 뭐먹을까요?", createTime: Date(), updateTime: Date(),contentImage: UIImage(named: "image1"), bookmark: false, bookmarkCount: 0, reply: [reply3,reply2,reply4,reply2], tilUrl: "")
+var posting4 = PostingInfo(user: user3, category: "고양이방", content: "저녁 야옹?", createTime: Date(), updateTime: Date(),contentImage: UIImage(named: "bookmark.fill"), bookmark: false, bookmarkCount: 0, reply: [reply3,reply2,reply4,reply2], tilUrl: "")
+var posting5 = PostingInfo(user: user5, category: "TIL", content: "UserDefault", createTime: Date(), updateTime: Date(),contentImage: UIImage(systemName: "lasso"), bookmark: true, bookmarkCount: 0, reply: [reply3,reply2,reply1], tilUrl: "")
+var posting6 = PostingInfo(user: user1, category: "잡담", content: "dd", createTime: Date(), updateTime: Date(),contentImage: UIImage(named: "defaultProfileImage"),bookmark: false, bookmarkCount: 0, reply: [reply2], tilUrl: "") // key -> kimseoni
+var posting7 = PostingInfo(user: user1, category: "잡담", content: "아니에요", createTime: Date(), updateTime: Date(),contentImage: UIImage(named: "defaultProfileImage"),bookmark: false, bookmarkCount: 0, reply: [reply1,reply4,reply2,reply2], tilUrl: "")
 
 var reply1 = ReplyInfo(user: user1, content: "빡세요", createTime: Date(), updateTime: Date())
+var reply2 = ReplyInfo(user: user2, content: "ㅠㅠ", createTime: Date(), updateTime: Date())
+var reply3 = ReplyInfo(user: user4, content: "fa", createTime: Date(), updateTime: Date())
+var reply4 = ReplyInfo(user: user2, content: "xcxz", createTime: Date(), updateTime: Date())
+var reply5 = ReplyInfo(user: user3, content: "ㅋㅋsad", createTime: Date(), updateTime: Date())
+var reply6 = ReplyInfo(user: user1, content: "rwqrqwr", createTime: Date(), updateTime: Date())
 
 var data = [posting1, posting2, posting3, posting4, posting5]

--- a/DOTORI/Extension/Date.swift
+++ b/DOTORI/Extension/Date.swift
@@ -8,9 +8,9 @@
 import Foundation
 
 extension Date{
-    func GetCurrentTime() -> String{
+    func GetCurrentTime(format : String) -> String{
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.dateFormat = format
         let dateString = formatter.string(from: self)
         return dateString
     }

--- a/DOTORI/View/DetailViewController.storyboard
+++ b/DOTORI/View/DetailViewController.storyboard
@@ -56,17 +56,17 @@
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Jvl-gj-wwP">
-                                            <size key="itemSize" width="216" height="155"/>
+                                            <size key="itemSize" width="342" height="148"/>
                                             <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                             <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                         </collectionViewFlowLayout>
                                         <cells>
                                             <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" reuseIdentifier="detailCollectionViewCell" id="Epw-6f-MPh" customClass="DetailCollectionViewCell" customModule="DOTORI" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="-7" width="216" height="155"/>
+                                                <rect key="frame" x="0.0" y="-3.6666666666666665" width="342" height="148"/>
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="BZz-j8-4q2">
-                                                    <rect key="frame" x="0.0" y="0.0" width="216" height="155"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="342" height="148"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="square.and.arrow.up.circle.fill" catalog="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mJi-1U-ApQ">
@@ -81,7 +81,7 @@
                                                     </constraints>
                                                 </collectionViewCellContentView>
                                                 <color key="backgroundColor" systemColor="systemMintColor"/>
-                                                <size key="customSize" width="216" height="155"/>
+                                                <size key="customSize" width="342" height="148"/>
                                                 <connections>
                                                     <outlet property="collectionImageView" destination="mJi-1U-ApQ" id="2w5-h3-R80"/>
                                                 </connections>
@@ -260,6 +260,53 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="96.946564885496173" y="-11.267605633802818"/>
+        </scene>
+        <!--Modify Reply Controller-->
+        <scene sceneID="eJb-NA-X2T">
+            <objects>
+                <viewController storyboardIdentifier="modifyReplyController" id="GNq-u8-KtB" customClass="ModifyReplyController" customModule="DOTORI" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="WFf-lH-RDW">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Bul-q8-BQG">
+                                <rect key="frame" x="11" y="16" width="54" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="이전"/>
+                                <connections>
+                                    <action selector="onbackPressed:" destination="GNq-u8-KtB" eventType="touchUpInside" id="mtu-Qg-5ou"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wae-Ng-Sgb">
+                                <rect key="frame" x="329" y="16" width="54" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="완료"/>
+                                <connections>
+                                    <action selector="oncompletePressed:" destination="GNq-u8-KtB" eventType="touchUpInside" id="F3w-PU-a0P"/>
+                                </connections>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="t8H-Js-tKk">
+                                <rect key="frame" x="16" y="94" width="366" height="269"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="o8O-E2-TdR"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <connections>
+                        <outlet property="contentTextView" destination="t8H-Js-tKk" id="OwC-Ce-Ifr"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="cS8-5g-GnF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1238.9312977099237" y="-11.267605633802818"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
디테일 페이지
-완료 
댓글 추가, 삭제, 수정 및 데이터 연동

-보완
UI 보완 필요

메인 페이지
-수정
디테일 페이지에 포스팅을 선택했을 때 인덱스 정보 넘겨줌

마이 페이지
-수정
디테일 페이지의 댓글 프로필을 클릭했을 때 프로필의 이름 정보를 받아옴

-그외 수정
1)더미 데이터 수정
2)Date extension GetCurrentTime함수 시간 포맷을 입력받아 수행되도록 수정  