### PR TITLE
이미지 투명일때 검정색나오는 문제와 잘리는 부분수정

### DIFF
--- a/DOTORI/Controller/DetailViewController.swift
+++ b/DOTORI/Controller/DetailViewController.swift
@@ -15,7 +15,7 @@ extension DetailViewController : UICollectionViewDelegate, UICollectionViewDataS
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if let dequeuedCell = imageCollectionView.dequeueReusableCell(withReuseIdentifier: "detailCollectionViewCell", for: indexPath) as? DetailCollectionViewCell {
             let posting = filter[selectedIndex]
-            dequeuedCell.collectionImageView.image = posting.contentImage?.resized(toWidth: 290, toHeight: 140)
+            dequeuedCell.collectionImageView.image = posting.contentImage?.resized(toWidth: 240, toHeight: 140)
             return dequeuedCell
         }
         else{
@@ -172,6 +172,7 @@ class DetailViewController: UIViewController,ModifyTextDelegate {
         replyInputTextField.delegate = self
         textView.translatesAutoresizingMaskIntoConstraints = true
         
+        imageCollectionView.backgroundColor = .white
         
         //처음 프로필 설정하는부분..
         let user = filter[selectedIndex].user
@@ -303,7 +304,7 @@ class PostingTableViewCell : UITableViewCell
     }
 }
 extension UIImage {
-    func resized(toWidth width: CGFloat, toHeight height : CGFloat, isOpaque: Bool = true) -> UIImage? {
+    func resized(toWidth width: CGFloat, toHeight height : CGFloat, isOpaque: Bool = false) -> UIImage? {
         let canvas = CGSize(width: width, height: height)
         let format = imageRendererFormat
         format.opaque = isOpaque

--- a/DOTORI/Controller/MyPageViewController.swift
+++ b/DOTORI/Controller/MyPageViewController.swift
@@ -99,18 +99,6 @@ class MyPageViewController: UIViewController, WKNavigationDelegate {
         }
     }
     
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        if segue.identifier == "UpdateMyPageSegue" {
-            if let updateMyPageVC = segue.destination as? UpdateMyPageViewController {
-                updateMyPageVC.delegate = self
-            }
-        } else if segue.identifier == "MyPageToDetail" {
-                if let destinationVC = segue.destination as? MyPageViewController {
-                    destinationVC.selectedIndex = selectedIndex!
-                }
-            }
-        }
-    }
 
 extension MyPageViewController : UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {


### PR DESCRIPTION
수정
-사진의 배경화면 색이 흰색일때  검정색나오는 부분과 이미지 살짝 잘리는부분 수정..

보완해야할 점
이중스크롤 화면구성시 루트기준으로 모든 뷰들이 통일하게 내리는 방법?