### PR TITLE
Feature/디테일버그

### DIFF
--- a/DOTORI/Controller/DetailViewController.swift
+++ b/DOTORI/Controller/DetailViewController.swift
@@ -49,6 +49,10 @@ class DetailViewController: UIViewController, ModifyTextDelegate, MYPageDelegate
     var selectedIndex = 0 //메인화면에서 넘겨주는 셀 인덱스
     var selectedModifyCellIndex = 0 //댓글에서 프로필 클릭시 프로필 정보의 셀 인덱스
     
+    override func viewWillDisappear(_ animated: Bool) {
+    self.navigationController?.popViewController(animated: true)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         scrollView.delegate = self
@@ -170,12 +174,6 @@ extension DetailViewController :  UITableViewDelegate, UITableViewDataSource{
         
         if let text = cell.nameLabel.text {
             myPageVC.selectedUserName = text
-        }
-        for i in 0..<data.count{
-            if data[i].user.name == cell.nameLabel.text
-            {
-                loginUser = data[i].user
-            }
         }
         myPageVC.delegate = self
         self.present(myPageVC, animated: true)

--- a/DOTORI/Controller/DetailViewController.swift
+++ b/DOTORI/Controller/DetailViewController.swift
@@ -17,7 +17,6 @@ enum UISheepPaperType {
         }
     }
 }
-//MARK: 본문 디테일 상세 뷰
 class DetailViewController: UIViewController, ModifyTextDelegate {
     //상단
     @IBOutlet weak var nameLabel: UILabel! //이름
@@ -155,6 +154,7 @@ class DetailViewController: UIViewController, ModifyTextDelegate {
 }
 
 extension DetailViewController :  UITableViewDelegate, UITableViewDataSource{
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return data[selectedIndex].reply.count
     }
@@ -198,10 +198,37 @@ extension DetailViewController :  UITableViewDelegate, UITableViewDataSource{
                 }
                 let storyboard = UIStoryboard(name: "MyPageViewController", bundle: nil)
                 let myPageVC = storyboard.instantiateViewController(withIdentifier: "MyPageViewController") as! MyPageViewController
-                
+
                 if let text = dequeuedCell.nameLabel.text {
                     myPageVC.selectedUserName = text
                 }
+                for i in 0..<data.count{
+                    if data[i].user.name == dequeuedCell.nameLabel.text
+                    {
+                        loginUser = data[i].user
+                    }
+                }
+
+                self.present(myPageVC, animated: true)
+                
+            }
+            dequeuedCell.profileSeeButtonAction = { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                let storyboard = UIStoryboard(name: "MyPageViewController", bundle: nil)
+                let myPageVC = storyboard.instantiateViewController(withIdentifier: "MyPageViewController") as! MyPageViewController
+
+                if let text = dequeuedCell.nameLabel.text {
+                    myPageVC.selectedUserName = text
+                }
+                for i in 0..<data.count{
+                    if data[i].user.name == dequeuedCell.nameLabel.text
+                    {
+                        loginUser = data[i].user
+                    }
+                }
+
                 self.present(myPageVC, animated: true)
             }
             return dequeuedCell
@@ -220,8 +247,6 @@ extension DetailViewController : UITextViewDelegate, UITextFieldDelegate
         return true
     }
 }
-
-//MARK: 댓글정보(클래스 이름 잘못설정했네..)
 class PostingTableViewCell : UITableViewCell
 {
     @IBOutlet weak var profileImageView: UIImageView!
@@ -234,20 +259,31 @@ class PostingTableViewCell : UITableViewCell
     var modifyButtonAction: (() -> Void)?
     var deleteButtonAction: (() -> Void)?
     var profileButtonAction : (() ->Void)?
+    var profileSeeButtonAction : (() ->Void)?
     
+    @IBAction func modifyOrDele(_ sender: Any) {
+                if  loginUser.name  == nameLabel.text{
+                    let menu = UIMenu(title: "", children: [
+                        UIAction(title: "수정",image: UIImage(systemName: "pencil"), handler: { _ in
+                            self.modifyButtonAction?()
+                        }),
+                        UIAction(title: "삭제", image: UIImage(systemName: "trash"), attributes: .destructive, handler: { _ in
+                            self.deleteButtonAction?()
+                        }),
+                    ])
+                    modifyOrDelteButton.showsMenuAsPrimaryAction = true
+                    modifyOrDelteButton.menu = menu
+                }else{
+                    let menu = UIMenu(title: "", children: [
+                        UIAction(title: "프로필 보기",image: UIImage(systemName: "person.crop.circle"), handler: { _ in
+                            self.profileSeeButtonAction?()
+                        }),
+                    ])
+                    modifyOrDelteButton.showsMenuAsPrimaryAction = true
+                    modifyOrDelteButton.menu = menu
+                }
+    }
     override func awakeFromNib() {
-        super.awakeFromNib()
-        let menu = UIMenu(title: "", children: [
-            UIAction(title: "수정", handler: { _ in
-                self.modifyButtonAction?()
-            }),
-            UIAction(title: "삭제", handler: { _ in
-                self.deleteButtonAction?()
-            }),
-        ])
-        modifyOrDelteButton.showsMenuAsPrimaryAction = true
-        modifyOrDelteButton.menu = menu
-        
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(profileImageTapped))
         profileImageView.addGestureRecognizer(tapGestureRecognizer)
         profileImageView.isUserInteractionEnabled = true

--- a/DOTORI/Controller/MyPageViewController.swift
+++ b/DOTORI/Controller/MyPageViewController.swift
@@ -15,7 +15,7 @@ class MyPageViewController: UIViewController, WKNavigationDelegate {
     var selectedUserName : String? //디테일페이지에서 클릭한 프로필의 유저 이름
     var selectedIndex : Int? // 마이페이지에서 클릭한 게시물 인덱스
     let webView = WKWebView()
-    
+    weak var delegate : MYPageDelegate?
     @IBOutlet weak var userButton: UIButton!
     @IBOutlet weak var mySetting: UIButton!
     @IBOutlet weak var profileImage: UIImageView!
@@ -91,7 +91,8 @@ class MyPageViewController: UIViewController, WKNavigationDelegate {
         })
         let settingMenu = UIMenu(title: "", children: [lightMode, darkMode])
         mySetting.menu = settingMenu
-        if let text = selectedUserName { name.text = text }
+        delegate?.updateUserInformation(profileImage: loginUser.profileImage, name: loginUser.name, nickname: loginUser.nickname)
+        
         loadPosting()
         loadAccount()
         tableView.dataSource = self
@@ -226,6 +227,7 @@ extension MyPageViewController: UpdateMyPageDelegate {
         loginUser.userIntro = userIntro
         tableView.reloadData()
         loadAccount()
+        delegate?.updateUserInformation(profileImage: profileImage, name: name, nickname: nickname)
         print("📣 계정 정보 업데이트")
     }
 }

--- a/DOTORI/View/DetailViewController.storyboard
+++ b/DOTORI/View/DetailViewController.storyboard
@@ -134,7 +134,7 @@
                                                                                 </constraints>
                                                                             </imageView>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="square.and.arrow.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="PnW-AG-Erl">
-                                                                                <rect key="frame" x="29" y="-1" width="25" height="25.333333333333336"/>
+                                                                                <rect key="frame" x="29" y="0.0" width="25" height="24.666666666666664"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="25" id="PV0-zT-dq7"/>
                                                                                     <constraint firstAttribute="width" constant="25" id="oB7-3v-kpK"/>
@@ -244,6 +244,9 @@
                                                                                     <color key="tintColor" systemColor="systemGrayColor"/>
                                                                                     <state key="normal" title="Button"/>
                                                                                     <buttonConfiguration key="configuration" style="plain" image="ellipsis.circle" catalog="system" buttonSize="small"/>
+                                                                                    <connections>
+                                                                                        <action selector="modifyOrDele:" destination="REs-Wo-Dsh" eventType="touchUpInside" id="LDb-Za-Mqt"/>
+                                                                                    </connections>
                                                                                 </button>
                                                                             </subviews>
                                                                         </stackView>

--- a/DOTORI/View/DetailViewController.storyboard
+++ b/DOTORI/View/DetailViewController.storyboard
@@ -134,7 +134,7 @@
                                                                                 </constraints>
                                                                             </imageView>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="square.and.arrow.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="PnW-AG-Erl">
-                                                                                <rect key="frame" x="29" y="0.0" width="25" height="24.666666666666664"/>
+                                                                                <rect key="frame" x="29" y="-1" width="25" height="25.333333333333336"/>
                                                                                 <constraints>
                                                                                     <constraint firstAttribute="height" constant="25" id="PV0-zT-dq7"/>
                                                                                     <constraint firstAttribute="width" constant="25" id="oB7-3v-kpK"/>
@@ -244,9 +244,6 @@
                                                                                     <color key="tintColor" systemColor="systemGrayColor"/>
                                                                                     <state key="normal" title="Button"/>
                                                                                     <buttonConfiguration key="configuration" style="plain" image="ellipsis.circle" catalog="system" buttonSize="small"/>
-                                                                                    <connections>
-                                                                                        <action selector="modifyOrDele:" destination="REs-Wo-Dsh" eventType="touchUpInside" id="LDb-Za-Mqt"/>
-                                                                                    </connections>
                                                                                 </button>
                                                                             </subviews>
                                                                         </stackView>

--- a/DOTORI/View/MyPageViewController.storyboard
+++ b/DOTORI/View/MyPageViewController.storyboard
@@ -428,6 +428,7 @@
                         <outlet property="name" destination="mLe-pu-Z0H" id="YUo-K8-qGN"/>
                         <outlet property="posting" destination="bfc-e2-Ice" id="Uvy-Lj-FLK"/>
                         <outlet property="postingCount" destination="l3h-2x-eoV" id="laq-YI-ssf"/>
+                        <outlet property="profileChangeButton" destination="GRC-zc-6yJ" id="cwp-aZ-ntC"/>
                         <outlet property="profileImage" destination="6Nl-Fm-9vR" id="N0u-iB-ck0"/>
                         <outlet property="tableView" destination="5ky-GN-odt" id="CWL-Hz-2cq"/>
                         <outlet property="userButton" destination="3Un-5A-qTP" id="S3e-7A-2DO"/>


### PR DESCRIPTION
수정
-디테일 페이지에서 모든 계정이 메뉴 버튼을 눌렀을때 수정/삭제만 보이는것을 로그인한 계정 기준으로 분류(로그인한 계정일시 "수정/삭제", 다른계정일시 "프로필 보기") 
-디테일 페이지에서 로그인한 사람이 아닌 계정의 프로필 사진을 클릭하거나 메뉴 "프로필 보기"를 선택할시 편집기능 숨기기 기능
